### PR TITLE
Adds flexbox styling to results view

### DIFF
--- a/src/components/styles/ListSearchView.css
+++ b/src/components/styles/ListSearchView.css
@@ -28,7 +28,10 @@
 .SearchResultCardContainer {
   width: calc(100% - 30px);
   position: relative;
-  top: 75px;
+  top: 125px;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
 }
 .ListSearchLanding {
   margin-top: 50px;

--- a/src/components/styles/SearchResultCard.css
+++ b/src/components/styles/SearchResultCard.css
@@ -1,7 +1,7 @@
 .SearchResultCard {
   padding: 15px;
-  margin: 15px;
-  width: 165px;
+  margin: 15px 10px 0 0;
+  width: 140px;
   min-height: 100px;
   background: #FFFFFF;
   box-shadow: 0 2px 4px 0 rgba(0,0,0,0.07);


### PR DESCRIPTION
This PR adds flexbox styling so that the results cards flow nicely on every mobile/tablet screen:

![screen shot 2017-06-14 at 15 56 04](https://user-images.githubusercontent.com/7193/27135905-0f8b3d10-511a-11e7-8738-9f87c4511987.jpg)
