### PR TITLE
[DONE] All parcels clickable on map

### DIFF
--- a/src/actions/ParcelActions.js
+++ b/src/actions/ParcelActions.js
@@ -1,4 +1,5 @@
 import i18next from "i18next";
+import { getParcels } from "lizard-api-client";
 import {
   SHOW_SNACKBAR,
   GET_ATTRIBUTES_FROM_GEOSERVER,
@@ -9,7 +10,7 @@ import {
 import { theStore } from "../store/Store";
 
 import { getParcelAttributes } from "../tools/wfs";
-
+import { receiveResultsSuccess } from "./SearchActions";
 import { changeView, showSnackBar } from "./UiActions";
 
 export const getAttributesFromGeoserverAction = parcelId => ({
@@ -147,4 +148,16 @@ export function getAttributesFromGeoserver(dispatch, parcelId) {
       );
     }
   );
+}
+
+export function getParcelByLatLng(dispatch, lat, lng) {
+  getParcels({
+    dist: 5, // 5 meter search radius
+    point: `${lng},${lat}`
+  }).then(results => {
+    if (results.length > 0) {
+      dispatch(receiveResultsSuccess(results));
+      getAttributesFromGeoserver(dispatch, results[0].id);
+    }
+  });
 }

--- a/src/components/MapComponent.jsx
+++ b/src/components/MapComponent.jsx
@@ -18,13 +18,12 @@ import {
 
 import styles from "./styles/MapComponent.css";
 
-import { getParcels } from "lizard-api-client";
-
 import {
   getAttributesFromGeoserver,
   getRaster,
   receiveResultsSuccess,
-  updateMapBbox
+  updateMapBbox,
+  getParcelByLatLng
 } from "../actions";
 
 import find from "lodash/find";
@@ -53,19 +52,10 @@ class MapComponent extends Component {
     ]);
   }
   handleMapClick(e) {
-    const { getDetails, receiveResults } = this.props;
+    const { getParcelByLatLng } = this.props;
     L.DomEvent.stopPropagation(e);
     const { lat, lng } = e.latlng;
-
-    getParcels({
-      dist: 10,
-      point: `${lng},${lat}`
-    }).then(results => {
-      if (results.length > 0) {
-        receiveResults(results);
-        getDetails(results[0].id);
-      }
-    });
+    getParcelByLatLng(lng, lat);
   }
   render() {
     const {
@@ -163,7 +153,10 @@ function mapDispatchToProps(dispatch) {
       getAttributesFromGeoserver(dispatch, id);
     },
     receiveResults: results => dispatch(receiveResultsSuccess(results)),
-    updateMapBbox: bbox => updateMapBbox(dispatch, bbox)
+    updateMapBbox: bbox => updateMapBbox(dispatch, bbox),
+    getParcelByLatLng: (lat, lng) => {
+      getParcelByLatLng(dispatch, lng, lat);
+    }
   };
 }
 


### PR DESCRIPTION
This PR makes it possible to click on a parcel that is not yet selected/in the store.

Testing
--------

To test this PR, make sure to `git pull origin master` your clone of `lizard-api-client` and run `yarn start` there.


Explanation
------------

- On click, the `getParcelByLatLng()` redux action gets dispatched.
- This calls the`getParcels()` function which is available [since this commit in lizard-api-client](https://github.com/nens/lizard-api-client/commit/430ff5701ce3dbedacad5a4635e11d3ebeee90ac)
- `getParcels()` can be passed an object which gets translated to GET parameters.
- The parcels API endpoint supports spatial filtering, so we pass `dist` and `point`.
- If parcels are found, dispatch the `receiveResultsSuccess()` action from SearchActions
- Finally, call the `getAttributesFromGeoserver()` action with the ID of the first (and probably only) result.


Demo
------

![jul-19-2017 12-45-43](https://user-images.githubusercontent.com/7193/28363283-3f000e14-6c80-11e7-86d0-9039ade5f42f.gif)
