### PR TITLE
[DONE] LoginLogoutButton position fix

### DIFF
--- a/src/components/styles/LoginLogoutButton.css
+++ b/src/components/styles/LoginLogoutButton.css
@@ -7,7 +7,9 @@
   text-align: center;
   width: 100px;
   position: absolute;
-  margin-top: 550px;
+  bottom: 0px;
+  left: 50%;
+  margin-left: -65px;
 }
 .Icon {
   transform: translateY(5px);


### PR DESCRIPTION
LoginLogoutButton now retains position on iOS10. Fixes https://github.com/nens/G4AW-lizard-client/issues/167.

Chrome on the left, iOS 10 on the right (in the official Simulator):
![screen shot 2017-08-21 at 08 47 36](https://user-images.githubusercontent.com/7193/29506794-b6f263d6-864d-11e7-8ab4-4b9324899afa.jpg)
